### PR TITLE
Remove dependency of Task towards ComputePlatform

### DIFF
--- a/hypertrainer/computeplatformtype.py
+++ b/hypertrainer/computeplatformtype.py
@@ -1,0 +1,8 @@
+from enum import Enum
+
+
+class ComputePlatformType(Enum):
+    LOCAL = 'local'
+    HELIOS = 'helios'
+    GRAHAM = 'graham'
+    BELUGA = 'beluga'

--- a/hypertrainer/dashboard.py
+++ b/hypertrainer/dashboard.py
@@ -47,7 +47,7 @@ def index():
 @bp.route('/monitor/<task_id>')
 def monitor(task_id):
     task = Task.get(Task.id == task_id)
-    task.monitor()
+    em.monitor(task)
     selected_log = 'out' if 'out' in task.logs else 'yaml'
 
     viz_scripts, viz_divs = None, None
@@ -90,7 +90,7 @@ def submit():
     script_file = request.form['script']
     config_file = request.form['config']
     project = request.form['project']
-    em.submit(platform, script_file, config_file, project=project)
+    em.create_tasks(platform, script_file, config_file, project=project)
     flash('Submitted "{}" with "{}" on {}.'.format(script_file, config_file, platform), 'success')
     return redirect(url_for('index'))
 

--- a/hypertrainer/dashboard.py
+++ b/hypertrainer/dashboard.py
@@ -25,12 +25,12 @@ def index():
         task_ids = [k.split('-')[1] for k, v in request.form.items() if k.startswith('check-') and v]
         a = request.form['action']
         if a == 'Cancel':
-            em.cancel_tasks(task_ids)
+            em.cancel_tasks(em.get_tasks_by_id(task_ids))
             flash('Cancelled task(s) {}.'.format(', '.join(task_ids)))
         elif a == 'Delete':
-            em.delete_tasks(task_ids)
+            em.delete_tasks_by_id(task_ids)
         elif a == 'Continue':
-            em.continue_tasks(task_ids)
+            em.continue_tasks(em.get_tasks_by_id(task_ids))
             flash('Resubmitted task(s) {}.'.format(', '.join(task_ids)))
     elif action == 'chooseproject':
         session['project'] = request.args.get('p')

--- a/hypertrainer/experimentmanager.py
+++ b/hypertrainer/experimentmanager.py
@@ -1,4 +1,4 @@
-from typing import Union
+from typing import Iterable
 
 from ruamel.yaml import YAML
 
@@ -83,16 +83,18 @@ class ExperimentManager:
         task.post_submit()
 
     @staticmethod
-    def continue_tasks(task_ids: list):
-        tasks = list(Task.select().where(Task.id.in_(task_ids)))
+    def get_tasks_by_id(task_ids: list):
+        return list(Task.select().where(Task.id.in_(task_ids)))
+
+    @staticmethod
+    def continue_tasks(tasks: Iterable[Task]):
         for t in tasks:
             if not t.status.is_active():
                 t.job_id = get_platform(t).submit(t, continu=True)  # TODO one bulk ssh command
                 t.post_continue()
 
     @staticmethod
-    def cancel_tasks(task_ids: list):
-        tasks = list(Task.select().where(Task.id.in_(task_ids)))
+    def cancel_tasks(tasks: Iterable[Task]):
         for t in tasks:
             if t.status.is_active():
                 get_platform(t).cancel(t)  # TODO one bulk ssh command
@@ -105,7 +107,7 @@ class ExperimentManager:
         t.interpret_logs()
 
     @staticmethod
-    def delete_tasks(task_ids: list):
+    def delete_tasks_by_id(task_ids: list):
         Task.delete().where(Task.id.in_(task_ids)).execute()
 
     @staticmethod

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -22,7 +22,7 @@ def test_submit(client):
     yaml = YAML()
 
     # 1. Launch task
-    experiment_manager.submit(script_file='script_test_submit.py', config_file='test_submit.yaml', platform='local')
+    experiment_manager.create_tasks(script_file='script_test_submit.py', config_file='test_submit.yaml', platform='local')
 
     # 2. Wait for it to finish, then get tasks
     sleep(2)
@@ -72,7 +72,7 @@ def test_continue(client):
     from hypertrainer.task import Task
     from hypertrainer.utils import TaskStatus
 
-    experiment_manager.submit(script_file='script_test_continue.py', config_file='test_continue.yaml', platform='local')
+    experiment_manager.create_tasks(script_file='script_test_continue.py', config_file='test_continue.yaml', platform='local')
     sleep(1)
 
     tasks = experiment_manager.get_all_tasks(do_update=True)

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -38,7 +38,7 @@ def test_submit(client):
                                                              'dummy_param_exp2', 'dummy_param_lin'])
 
         # Check output
-        t.monitor()
+        experiment_manager.monitor(t)
         assert t.logs['err'].strip() == 'printing to stderr'
         assert t.logs['out'].strip() == 'printing to stdout'
 

--- a/tests/test_dashboard.py
+++ b/tests/test_dashboard.py
@@ -80,7 +80,7 @@ def test_continue(client):
     t = tasks[0]  # type: Task
     assert t.status == TaskStatus.Finished
 
-    t.continu()
+    experiment_manager.continue_tasks([t])
     sleep(1)
 
     tasks = experiment_manager.get_all_tasks(do_update=True)


### PR DESCRIPTION
In the current architecture, we have to `import Task` wherever we want to perform a query on the database. This means, for example, that since Task depends on ComputePlatform, we cannot perform queries on the database in ComputePlatform code.

For this reason, I suggest to remove the dependency from Task towards ComputePlatform.

There might be a better solution, looking forwards to discuss this.